### PR TITLE
setup test visibility with Datadog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_call:
   schedule:
-    - cron: "0 10 * * *" # every day at 10:00 UTC
+    - cron: '0 10 * * *' # every day at 10:00 UTC
 
 jobs:
   test:
@@ -34,4 +34,9 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run tests
+      env:
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+        DD_CIVISIBILITY_ITR_ENABLED: true
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_ENV: ci
       run: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 gemfile = "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION.split(".").take(2).join(".")}.gemfile"
 eval_gemfile "gemfiles/#{gemfile}"
+
+gem "datadog-ci", "~> 1.0.0.beta5"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,12 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+if ENV["DD_ENV"] == "ci"
+  Datadog.configure do |c|
+    c.service = "leash"
+
+    c.ci.enabled = true
+    c.ci.instrument :rspec
+  end
+end


### PR DESCRIPTION
Adds test visibility support


Steps needed from your side:
- add DD_API_KEY to secrets and run the test workflow
- after tests appear in https://app.datadoghq.com/ci/test-services, go to  https://app.datadoghq.com/ci/settings/test-service and enable Intelligent test runner for leash